### PR TITLE
Handled # in the URL breaking the share-code appending logic

### DIFF
--- a/src/js/share.js
+++ b/src/js/share.js
@@ -25,10 +25,14 @@
 	  * @private
 	  */
 
-	function urlParametersAlreadyHaveShareCode(parameters){
+	function urlAlreadyHasShareCode(url){
 
-		return parameters.indexOf('share_code') > -1 ? true : false;
+		return url.indexOf('share_code') > -1 ? true : false;
 
+	}
+
+	function urlHasAHashSignInIt(url){
+		return url.indexOf('#') > -1 ? true : false;
 	}
 
 	function removeExisingShareCodeFromURL(){
@@ -374,7 +378,8 @@
 	}
 
 	Share.addShareCodeToUrl = function () {
-		if (urlParametersAlreadyHaveShareCode(window.location.search)) {
+
+		if (urlAlreadyHasShareCode(window.location.href) || urlHasAHashSignInIt(window.location.href)) {
 			const otherParameters = removeExisingShareCodeFromURL();
 			let newURL = window.location.href.split('?')[0];
 
@@ -392,10 +397,9 @@
 				.then(function (data) {
 					if (data.success) {
 						const code = data.data.shareCode;
-
 						const join = (window.location.href.indexOf("?") > -1) ? "&" : "?";
 
-						window.history.pushState({}, undefined, window.location.href + join + "share_code=" + code);
+						window.history.pushState({}, undefined, window.location.href.split('#')[0] + join + "share_code=" + code);
 					}
 				});
 			}, 5000);

--- a/src/js/share.js
+++ b/src/js/share.js
@@ -1,23 +1,23 @@
-	/**global require, module, window, CustomEvent, document, HTMLElement, location */
-	const serviceURL = "https://sharecode-test.ft.com";
-	const DomDelegate = require('ftdomdelegate');
-	const qs = require('query-string');
-	const Tooltip = require('./Tooltip');
+/**global require, module, window, CustomEvent, document, HTMLElement, location */
+const serviceURL = "https://sharecode-test.ft.com";
+const DomDelegate = require('ftdomdelegate');
+const qs = require('query-string');
+const Tooltip = require('./Tooltip');
 
-	const socialUrls = {
-		twitter: 'https://twitter.com/intent/tweet?url={{url}}&amp;text={{title}}&amp;related={{relatedTwitterAccounts}}&amp;via=FT',
-		facebook: 'http://www.facebook.com/sharer.php?u={{url}}&amp;t={{title}}+|+{{titleExtra}}',
-		linkedin: 'http://www.linkedin.com/shareArticle?mini=true&amp;url={{url}}&amp;title={{title}}+|+{{titleExtra}}&amp;summary={{summary}}&amp;source=Financial+Times',
-		googleplus: 'https://plus.google.com/share?url={{url}}',
-		reddit: 'http://reddit.com/submit?url={{url}}&amp;title={{title}}',
-		pinterest: 'http://www.pinterest.com/pin/create/button/?url={{url}}&amp;description={{title}}',
-		url: '{{url}}',
-		email: 'mailto:?subject=See this article on FT.com&body={{title}}%0A{{url}}'
-	};
+const socialUrls = {
+	twitter: 'https://twitter.com/intent/tweet?url={{url}}&amp;text={{title}}&amp;related={{relatedTwitterAccounts}}&amp;via=FT',
+	facebook: 'http://www.facebook.com/sharer.php?u={{url}}&amp;t={{title}}+|+{{titleExtra}}',
+	linkedin: 'http://www.linkedin.com/shareArticle?mini=true&amp;url={{url}}&amp;title={{title}}+|+{{titleExtra}}&amp;summary={{summary}}&amp;source=Financial+Times',
+	googleplus: 'https://plus.google.com/share?url={{url}}',
+	reddit: 'http://reddit.com/submit?url={{url}}&amp;title={{title}}',
+	pinterest: 'http://www.pinterest.com/pin/create/button/?url={{url}}&amp;description={{title}}',
+url: '{{url}}',
+	email: 'mailto:?subject=See this article on FT.com&body={{title}}%0A{{url}}'
+};
 
-	const shareUrlPromises = {};
+const shareUrlPromises = {};
 
-	let tokenTimeout = undefined;
+let tokenTimeout = undefined;
 
 	/**
 	  * Checks if a passed url has sharecode parameter in it

--- a/src/js/share.js
+++ b/src/js/share.js
@@ -1,5 +1,4 @@
 /**global require, module, window, CustomEvent, document, HTMLElement, location */
-const serviceURL = "https://sharecode-test.ft.com";
 const DomDelegate = require('ftdomdelegate');
 const qs = require('query-string');
 const Tooltip = require('./Tooltip');

--- a/src/js/share.js
+++ b/src/js/share.js
@@ -25,9 +25,9 @@
 	  * @private
 	  */
 
-	function urlAlreadyHasShareCode(url){
+	function urlParametersAlreadyHaveShareCode(parameters){
 
-		return url.indexOf('share_code') > -1 ? true : false;
+		return parameters.indexOf('share_code') > -1 ? true : false;
 
 	}
 
@@ -35,9 +35,9 @@
 		return url.indexOf('#') > -1 ? true : false;
 	}
 
-	function removeExisingShareCodeFromURL(){
+	function removeExisingShareCodeFromURL(parameters){
 
-		const params = qs.parse(window.location.search);
+		const params = qs.parse(parameters);
 		delete params.share_code;
 
 		return qs.stringify(params);
@@ -379,15 +379,15 @@
 
 	Share.addShareCodeToUrl = function () {
 
-		if (urlAlreadyHasShareCode(window.location.href) || urlHasAHashSignInIt(window.location.href)) {
-			const otherParameters = removeExisingShareCodeFromURL();
+		if (urlParametersAlreadyHaveShareCode(window.location.search)) {
+			const otherParameters = removeExisingShareCodeFromURL(window.location.search);
 			let newURL = window.location.href.split('?')[0];
 
 			if (otherParameters !== ''){
 				newURL += '?' + otherParameters;
 			}
 
-			window.history.pushState({}, undefined, newURL);
+			window.history.pushState({}, undefined, newURL + window.location.hash);
 
 		}
 
@@ -397,9 +397,11 @@
 				.then(function (data) {
 					if (data.success) {
 						const code = data.data.shareCode;
-						const join = (window.location.href.indexOf("?") > -1) ? "&" : "?";
+						const params = qs.parse(window.location.search);
+						params.share_code = code;
+						const newQueryString = qs.stringify(params);
 
-						window.history.pushState({}, undefined, window.location.href.split('#')[0] + join + "share_code=" + code);
+						window.history.pushState({}, undefined, window.location.origin + window.location.pathname + '?' + newQueryString + window.location.hash);
 					}
 				});
 			}, 5000);

--- a/src/js/share.js
+++ b/src/js/share.js
@@ -394,18 +394,6 @@ Share.init = function(el, config) {
 	return shareInstances;
 };
 
-Share.addShareCodeToUrl = function (serviceURL = defaultServiceUrl, shareAmount = defaultShareAmount) {
-	if (urlParametersAlreadyHaveShareCode(window.location.search)) {
-		const otherParameters = removeExisingShareCodeFromURL();
-		let newURL = window.location.href.split('?')[0];
-
-		if (otherParameters !== ''){
-			newURL += '?' + otherParameters;
-		}
-
-		window.history.pushState({}, undefined, newURL);
-
-	}
 
 	Share.addShareCodeToUrl = function (serviceURL = defaultServiceUrl, shareAmount = defaultShareAmount) {
 
@@ -438,7 +426,6 @@ Share.addShareCodeToUrl = function (serviceURL = defaultServiceUrl, shareAmount 
 
 		}
 
-	}
 
 }
 


### PR DESCRIPTION
A hash in the URL (#myft:my-news:myft-tray for example) It breaks our url creation logic (window.location.search returns '' instead of the query parameters). This fixes that.
